### PR TITLE
Add id to layer added with add layer widget

### DIFF
--- a/jimu.js/main.js
+++ b/jimu.js/main.js
@@ -45,6 +45,7 @@ define(["./ConfigManager",
 
     window.layerIdPrefix = "eaLyrNum_";
     window.layerIdTiledPrefix = "tiledNum_";
+    window.addedLayerIdPrefix = "added_";
     window.removeAllMessage = "removeAll";
     window.bFirstLoadFilterWidget = true;
     window.allLayerNumber = [];

--- a/widgets/AddService/Widget.js
+++ b/widgets/AddService/Widget.js
@@ -240,7 +240,7 @@ function(declare,
 				
 				var dynamicMapServiceLayer = new ArcGISDynamicMapServiceLayer(serviceURL);
 				dynamicMapServiceLayer.name = parentLayerName; // 1.1.1 - Sets dynamic service name
-				dynamicMapServiceLayer.id = "Added_" + dynamicMapServiceLayer.name;
+				dynamicMapServiceLayer.id = window.addedLayerIdPrefix + dynamicMapServiceLayer.name;
 				map.addLayer(dynamicMapServiceLayer);
 					// layer loaded listener 
 					dynamicMapServiceLayer.on("load", function(){
@@ -272,7 +272,7 @@ function(declare,
 					
 				var tiledMapServiceLayer = new ArcGISTiledMapServiceLayer(serviceURL);
 				tiledMapServiceLayer.name = parentLayerName;// 1.1.1 - Sets tiled service name
-					tiledMapServiceLayer.id = "Added_" + tiledMapServiceLayer.name;
+					tiledMapServiceLayer.id = window.addedLayerIdPrefix + tiledMapServiceLayer.name;
 				map.addLayer(tiledMapServiceLayer);
 					// layer loaded listener 
 					tiledMapServiceLayer.on("load", function(){
@@ -305,7 +305,7 @@ function(declare,
 				else{
 				var imageServiceLayer = new ArcGISImageServiceLayer(serviceURL);
 				imageServiceLayer.name = parentLayerName; // 1.1.1 - Sets tiled service name
-				imageServiceLayer.id = "Added_" + parentLayerName;
+				imageServiceLayer.id = window.addedLayerIdPrefix + parentLayerName;
 				map.addLayer(imageServiceLayer);
 					// layer loaded listener 
 					imageServiceLayer.on("load", function(){
@@ -341,7 +341,7 @@ function(declare,
 			//wms radio button is checked
 				var wmsLayer = new WMSLayer(serviceURL);
 				wmsLayer.setImageFormat ("png");
-				wmsLayer.id = "Added_";
+				wmsLayer.id = window.addedLayerIdPrefix;
 				map.addLayer(wmsLayer);
 					wmsLayer.on("load", function(){
 						console.log("WMS service Loaded successfully");

--- a/widgets/Addfile/Widget.js
+++ b/widgets/Addfile/Widget.js
@@ -171,7 +171,7 @@ define([
                     var featureLayer = new FeatureLayer(layer, {
                         //infoTemplate: infoTemplate
                     });
-
+                    featureLayer.id = window.addedLayerIdPrefix + featureLayer.name;
 
                     //associate the feature with the popup on click to enable highlight and zoom to
                     featureLayer.on('click', function (event) {
@@ -351,7 +351,7 @@ define([
 
                         var featureLayerCSV = new FeatureLayer(featureCollection, {
                             infoTemplate: infoTemplate,
-                            id: csvFileName,
+                            id: window.addedLayerIdPrefix + csvFileName,
                             name: csvFileName
                         });
                         featureLayerCSV.__popupInfo = popupInfo;


### PR DESCRIPTION
added window.addedLayerIDPrefix to main.js and then utilized it in the Add File and Add Service widgets. Now when layers are added by these widgets the ID's of those layer will have a prefix of "added_"
