### PR TITLE
Remove unneeded title space to maximize screen space for TOC.

### DIFF
--- a/themes/TabTheme/panels/TabPanel/style.css
+++ b/themes/TabTheme/panels/TabPanel/style.css
@@ -4,6 +4,7 @@
   border: 1px solid transparent;
 }
 .tab-widget-frame .title{
+  display: none;
   overflow: hidden;
 }
 .tab-widget-frame .title-label{

--- a/themes/TabTheme/widgets/SidebarController/css/style.css
+++ b/themes/TabTheme/widgets/SidebarController/css/style.css
@@ -82,7 +82,7 @@
   left: 0;
   right: 0;
   top: -1px;
-  height: 18px;
+  height: 0;
   opacity: 0.2;
 }
 .jimu-widget-sidebar-controller .content-title{
@@ -95,7 +95,7 @@
 .jimu-widget-sidebar-controller .content-pane{
   position: absolute;
   left: 0;
-  top: 18px;
+  top: 0;
   right: 0;
   bottom: 0;
   overflow: hidden;


### PR DESCRIPTION
Seems like we would eventually want to add some subtle visual indication of which tab is selected similar to the hover effect shown on mouseover.
