### PR TITLE
Adjusted width of drawer widget panel

### DIFF
--- a/config.json
+++ b/config.json
@@ -240,7 +240,7 @@
 				"position" : {
 					"left" : 495,
 					"top" : 5,
-					"width" : 170,
+					"width" : 230,
 					"height" : 185,
 					"relativeTo" : "map"
 				},


### PR DESCRIPTION
This is just to make the drawer widget panel wide enough to see the whole title.