### PR TITLE
#263 allow multiple tools/popups to be visible at the same time

### DIFF
--- a/config.json
+++ b/config.json
@@ -266,8 +266,8 @@
 				"position" : {
 					"left" : 595,
 					"top" : 5,
-					"width" : 410,
-					"height" : 490,
+					"width" : 425,
+					"height" : 480,
 					"relativeTo" : "map"
 				},
 				"placeholderIndex" : 1,

--- a/config.json
+++ b/config.json
@@ -267,7 +267,7 @@
 					"left" : 595,
 					"top" : 5,
 					"width" : 410,
-					"height" : 480,
+					"height" : 490,
 					"relativeTo" : "map"
 				},
 				"placeholderIndex" : 1,

--- a/configs/Print/config_Print.json
+++ b/configs/Print/config_Print.json
@@ -1,5 +1,5 @@
 {
-  "serviceURL": "http://geodata.epa.gov/arcgis/rest/services/Utilities/PrintingTools/GPServer/Export%20Web%20Map%20Task",
+  "serviceURL": "https://map11.epa.gov/arcgis/rest/services/Utilities/PrintingTools/GPServer/Export%20Web%20Map%20Task",
   "defaultTitle": "EnviroAtlas Map Export",
   "defaultAuthor": "EnviroAtlas User",
   "defaultCopyright": "U.S. Environmental Protection Agency",

--- a/jimu.js/OnScreenWidgetIcon.js
+++ b/jimu.js/OnScreenWidgetIcon.js
@@ -104,7 +104,7 @@ function(declare, lang, array, html, on, _WidgetBase, utils) {
     switchToOpen: function(){
       this.state = 'opened';
 
-      this.panelManager.closeAllPanelsInGroup(this.widgetConfig.gid);
+      //this.panelManager.closeAllPanelsInGroup(this.widgetConfig.gid);
       array.forEach(this.widgetManager.getOnScreenOffPanelWidgets(), function(widget){
         if(widget.closeable){
           this.widgetManager.closeWidget(widget);

--- a/jimu.js/css/jimu.css
+++ b/jimu.js/css/jimu.css
@@ -2570,7 +2570,9 @@ widget:jimu-w
   white-space: nowrap;
   text-overflow: ellipsis;
   overflow: hidden;
-  width: 100%;
+  width: -webkit-calc(100% - 35px);
+  width:    -moz-calc(100% - 35px);
+  width:         calc(100% - 35px);
 }
 .jimu-on-screen-widget-panel>.jimu-panel-title>.close-btn,
 .jimu-on-screen-widget-panel>.jimu-panel-title>.foldable-btn,


### PR DESCRIPTION
Made multiple widgets visible (open widgets don't auto-close) and restored "close" button.  Can get messy fast.  Drawer widget is exception - it closes when subwidgets open, wondering about whether we want that to change.  Also fixed URL for print widget.