### PR TITLE
fix definition query code in dynamic symbology widget

### DIFF
--- a/widgets/DynamicSymbology/Widget.js
+++ b/widgets/DynamicSymbology/Widget.js
@@ -149,9 +149,6 @@ function(declare, BaseWidget, LayerInfos, dom, domConstruct, on, domStyle, Map, 
 
 		  //Set layers
 		  geoenrichedFeatureLayer = dynamicSym.map.getLayer(_layerID);
-		  //console.log("FeatureLayer: ", geoenrichedFeatureLayer.renderer);
-		  var comName = window.communityDic[window.communitySelected];
-		  geoenrichedFeatureLayer.setDefinitionExpression("Community like '%" + comName + "%'");
 
 		  featureLayerStatistics = new FeatureLayerStatistics({layer: geoenrichedFeatureLayer, visible: false});
 


### PR DESCRIPTION
I was able to fix the issue that we identified yesterday with the definition query in the dynamic symbology widget. Now it will reflect the definition query assigned by the community widget to the layer. It also fixed the issue we saw with using the dynamic symbology widget on the national layers. 