### PR TITLE
Set _scheme to null when dynamic symbology widget starts

### DIFF
--- a/widgets/DynamicSymbology/Widget.js
+++ b/widgets/DynamicSymbology/Widget.js
@@ -67,7 +67,8 @@ function(declare, BaseWidget, LayerInfos, dom, domConstruct, on, domStyle, Map, 
 
     startup: function() {
 	  this.inherited(arguments);
-	  
+        _scheme = null;
+
 	  this.fetchDataByName('LayerList');
 	  
 	  console.log('startup')


### PR DESCRIPTION
This should fix the error occurring in the dynamic symbology widget