### PR TITLE
Edited context menu options

### DIFF
--- a/widgets/LayerList/PopupMenuInfo.js
+++ b/widgets/LayerList/PopupMenuInfo.js
@@ -144,12 +144,12 @@ define([
       }, {
         key: 'transparency',
         label: this.nls.itemTransparency
-      //}, {
-      //  key: 'moveup',
-      //  label: this.nls.itemMoveUp
-      //}, {
-      //  key: 'movedown',
-      //  label: this.nls.itemMoveDown
+      }, {
+        key: 'moveup',
+        label: this.nls.itemMoveUp
+      }, {
+        key: 'movedown',
+        label: this.nls.itemMoveDown
       }, {
         key: 'table',
         label: this.nls.itemToAttributeTable
@@ -594,26 +594,36 @@ define([
     var itemInfoCategoreList = {
       'RootLayer': [
       {
-        key: 'mapDescription'
-      }, {
-        key: 'movetotop'
-      }, {
         key: 'transparency'
       }, {
         key: 'remove'
+      },{
+        key: 'separator'
+      }, {
+        key: 'mapDescription'
+      }, {
+        key: 'url'
       }, {
         key: 'separator'
+      }, {
+        key: 'movetotop'
       }, {
         key: 'moveup'
       }, {
         key: 'movedown'
-      }, {
-        key: 'separator'
-      }, {
-        key: 'url'
-      }],
+      } ],
       'RootLayerAndFeatureLayer': [
       {
+        key: 'transparency'
+      }, {
+        key: 'changeSymbology'
+      }, {
+        key: 'controlPopup'
+      }, {
+        key: 'remove'
+      }, {
+        key: 'separator'
+      },  {
         key: 'mapDescription'
       }, {
         key: 'dataFactSheet'
@@ -622,25 +632,17 @@ define([
       }, {
         key: 'metadataDownload'
       }, {
-        key: 'changeSymbology'
+        key: 'separator'
       }, {
-        key: 'remove'
+        key: 'table'
       }, {
         key: 'separator'
       }, {
         key: 'movetotop'
       }, {
-        key: 'transparency'
-      }, {
-        key: 'controlPopup'
-      }, {
         key: 'moveup'
       }, {
         key: 'movedown'
-      }, {
-        key: 'separator'
-      }, {
-        key: 'table'
       }],
       'FeatureLayer': [{
         key: 'controlPopup'

--- a/widgets/LayerList/nls/strings.js
+++ b/widgets/LayerList/nls/strings.js
@@ -17,12 +17,12 @@ define({
     itemToAttributeTable: "Open Attribute Table",
     itemShowItemDetails: "Show Item Details",
     empty: "empty",
-    removePopup: "Disable Pop-up",
-    enablePopup: "Enable Pop-up",
+    removePopup: "Disable ID Pop-up",
+    enablePopup: "Enable ID Pop-up",
     itemDataFactSheet: "Data Fact Sheet",
     itemMetadataDownload: "Metadata/Download",
-    itemChangeSymbology: "Change Symbology",
-    itemRemove: "Remove"   
+    itemChangeSymbology: "Change Appearance",
+    itemRemove: "Remove Layer"   
   }),
   "ar": 1,
   "cs": 1,


### PR DESCRIPTION
In this pull request, I uncommented the move up/down options for testing - I'm thinking that Baohong is right, we're not going to want to keep them enabled, but I'd like to at least run a few tests with the code deployed on staging - it's easy to comment them again.