### PR TITLE
Symbology widget should add definition expression

### DIFF
--- a/widgets/DynamicSymbology/Widget.js
+++ b/widgets/DynamicSymbology/Widget.js
@@ -442,6 +442,7 @@ function(declare, BaseWidget, LayerInfos, dom, domConstruct, on, domStyle, Map, 
 		dynamicSymbology.classSelect.destroy();
 		dynamicSymbology = {};
 
+		geoenrichedFeatureLayer.setDefinitionExpression("");
       	console.log('onClose');
     },
 

--- a/widgets/DynamicSymbology/Widget.js
+++ b/widgets/DynamicSymbology/Widget.js
@@ -150,7 +150,7 @@ function(declare, BaseWidget, LayerInfos, dom, domConstruct, on, domStyle, Map, 
 
 		  //Set layers
 		  geoenrichedFeatureLayer = dynamicSym.map.getLayer(_layerID);
-
+		  geoenrichedFeatureLayer.setDefinitionExpression("CommST = '" + window.communitySelected + "'");
 		  featureLayerStatistics = new FeatureLayerStatistics({layer: geoenrichedFeatureLayer, visible: false});
 
 		  //set store original renderer


### PR DESCRIPTION
Added the definition expression back on to the symbology widget but also add functionality to remove the definition expression once the symbology widget has closed.  