### PR TITLE
Addded warning text to the dynamic Symbology tool for national layers

### DIFF
--- a/widgets/DynamicSymbology/Widget.html
+++ b/widgets/DynamicSymbology/Widget.html
@@ -3,8 +3,10 @@
 	<!--<div>${nls.label2}.[${config.configText}]</div>-->
 
   <div data-dojo-attach-point="mapIdNode"></div>
+
 	<div id="esri-colorinfoslider-container">
 		<div id="title" data-dojo-attach-point="titleNode"></div>
+		<div id="nationalDSWarning" class="nationalWarningText"><p>${nls.nationalLayerText}.</p></div>
 		<div id="layerSelect"></div>
 		<hr>
 		<!--<div>-->

--- a/widgets/DynamicSymbology/Widget.js
+++ b/widgets/DynamicSymbology/Widget.js
@@ -167,8 +167,11 @@ function(declare, BaseWidget, LayerInfos, dom, domConstruct, on, domStyle, Map, 
           var str = geoenrichedFeatureLayer.url;
           var lookfor = "National";
           if(str.indexOf(lookfor)>-1){
+          	//add warning for national data
+              domStyle.set(dom.byId('nationalDSWarning'), "display", "inline");
               geoenrichedFeatureLayer.setDefinitionExpression(geoenrichedFeatureLayer.renderer.attributeField + " >= 0" + " AND " + geoenrichedFeatureLayer.renderer.attributeField + " IS NOT Null" );
 		  }else{
+              domStyle.set(dom.byId('nationalDSWarning'), "display", "none");
               if(window.communitySelected != "AllCommunity"){
                 geoenrichedFeatureLayer.setDefinitionExpression("CommST = '" + window.communitySelected + "'" + " AND " + geoenrichedFeatureLayer.renderer.attributeField + " >= 0" + " AND " + geoenrichedFeatureLayer.renderer.attributeField + " IS NOT Null" );
               }
@@ -489,6 +492,7 @@ function(declare, BaseWidget, LayerInfos, dom, domConstruct, on, domStyle, Map, 
 
     onClose: function(){
 		//clean up
+        domStyle.set(dom.byId('nationalDSWarning'), "display", "none");
 		dijit.byId("transSlider").destroy();
 
 		styleDialog.destroy();

--- a/widgets/DynamicSymbology/css/style.css
+++ b/widgets/DynamicSymbology/css/style.css
@@ -1,6 +1,13 @@
 .jimu-widget-demo {
   
 }
+#title{
+    font-weight: bold;
+}
+.nationalWarningText{
+    font-size: smaller;
+    display: none;
+}
 
 .color{
   height: 20px;

--- a/widgets/DynamicSymbology/nls/strings.js
+++ b/widgets/DynamicSymbology/nls/strings.js
@@ -2,7 +2,8 @@ define({
   root: ({
     _widgetLabel: "Demo",
     label1: "I am a demo widget.",
-    label2: "This is configurable."
+    label2: "This is configurable.",
+    nationalLayerText: "Changing the appearance of national layers is not possible when you are zoomed out beyond a multi-county area. Zoom in to view data with customized appearance or use the reset button to return to the default appearance."
   }),
   "ar": 0,
   "cs": 0,


### PR DESCRIPTION
Warning text of "Changing the appearance of national layers is not possible when you are zoomed out beyond a multi-county area. Zoom in to view data with customized appearance or use the reset button to return to the default appearance."
 